### PR TITLE
Fixed Attribute Error in ParseTab

### DIFF
--- a/examples/ParseTab.py
+++ b/examples/ParseTab.py
@@ -61,7 +61,7 @@ def ParseTab(page, bbox, columns=None):
     if xmax > coltab[-1]:
         coltab.append(xmax)
 
-    words = page.get_textWords()
+    words = page.getTextWords()
 
     if words == []:
         print("Warning: page contains no text")


### PR DESCRIPTION
Replaced get_textWords() with getTextWords() to fix the error below:

Traceback (most recent call last):
  File "<path-to-file>/wxTableExtract.py", line 588, in GetMatrix
    self.parsed_table = ParseTab(self.doc[pg], [x0, y0, x1, y1],
  File "<path-to-file>/ParseTab.py", line 58, in ParseTab        
    words = page.get_textWords()
AttributeError: 'Page' object has no attribute 'get_textWords'