### PR TITLE
join_tables.ipynb - fix: correct logic check for empty tables

### DIFF
--- a/table-analysis/join_tables.ipynb
+++ b/table-analysis/join_tables.ipynb
@@ -290,7 +290,7 @@
     "\n",
     "for page in doc:  # iterate over the pages\n",
     "    tabs = page.find_tables()  # locate tables on page\n",
-    "    if len(tabs.tables) == []:  # no tables found?\n",
+    "    if tabs.tables == []:  # no tables found?\n",
     "        break  # stop\n",
     "    tab = tabs[0]  # assume fragment to be 1st table\n",
     "    dataframes.append(tab.to_pandas())  # append this DataFrame\n",


### PR DESCRIPTION
fix: correct logic check for empty tables

Changed `if len(tabs.tables) == []` to `if tabs.tables == []` to fix incorrect comparison between length and empty list